### PR TITLE
modifies ssh key name

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -49,7 +49,7 @@ jobs:
               env:
                 - inst_type: "t2.micro"
                 - inst_ami: "ami-43a15f3e"
-                - aws_key_name: "dr_us_east_1"
+                - aws_key_name: "dr_us_east_1_tf"
           script:
             - pushd $(shipctl get_resource_state "aws_ec2_tf_repo")
             - export AWS_ACCESS_KEY_ID=$(shipctl get_integration_resource_field aws_ec2_tf_creds "accessKey")
@@ -95,7 +95,7 @@ jobs:
               env:
                 - inst_type: "t2.micro"
                 - inst_ami: "ami-43a15f3e"
-                - aws_key_name: "dr_us_east_1"
+                - aws_key_name: "dr_us_east_1_tf"
           script:
             - pushd $(shipctl get_resource_state "aws_ec2_tf_repo")
             - export AWS_ACCESS_KEY_ID=$(shipctl get_integration_resource_field aws_ec2_tf_creds "accessKey")


### PR DESCRIPTION
https://github.com/devops-recipes/prov_aws_ec2_terraform/issues/1

The latest build for provisioning ec2 machine fails.

https://app.shippable.com/github/devops-recipes/jobs/prov_aws_ec2_tf/builds/5b62a1ace815be06001047e8/console 

This is because, a key named `dr_us_east_1` is already manually created in AWS console and also being used in other places like https://github.com/devops-recipes/prov_aws_ec2_ansible 

But, we have modified the terraform script to create a new keypair everytime we do `terraform apply` and  destroy it whenever we do `terraform destroy` in the deprov job. so, renaming the key name to add `_tf` at the end to make the name unique and to imply that it will be available only during the course of running the terraform scripts.